### PR TITLE
Make the feature_flags attribute optional in Config

### DIFF
--- a/platzky/config.py
+++ b/platzky/config.py
@@ -42,7 +42,7 @@ class Config(StrictBaseModel):
     )
     debug: bool = Field(default=False, alias="DEBUG")
     testing: bool = Field(default=False, alias="TESTING")
-    feature_flags: dict[str, bool] = Field(default_factory=dict, alias="FEATURE_FLAGS")
+    feature_flags: t.Optional[dict[str, bool]] = Field(default_factory=dict, alias="FEATURE_FLAGS")
 
     @classmethod
     def model_validate(


### PR DESCRIPTION
The app used to fail with error, when `FEATURE_FLAGS:` was empty in yaml config.
Now it is optional.