### PR TITLE
chore: configure semantic-release for next branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - main
       - next
 
-# default: least privileged permissions across all jobs
 permissions:
   contents: read
   id-token: write
@@ -87,8 +86,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: release
-    # Only deploy to PyPI from main branch (not alpha releases from next)
-    if: ${{ needs.release.outputs.released == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.release.outputs.released == 'true' }}
 
     environment:
       name: pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - next
 
 # default: least privileged permissions across all jobs
 permissions:
@@ -86,7 +87,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: release
-    if: ${{ needs.release.outputs.released == 'true' }}
+    # Only deploy to PyPI from main branch (not alpha releases from next)
+    if: ${{ needs.release.outputs.released == 'true' && github.ref == 'refs/heads/main' }}
 
     environment:
       name: pypi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - next
   workflow_call:
 
 permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,11 @@ changelog_file = "CHANGELOG.md"
 match = "main"
 prerelease = false
 
+[tool.semantic_release.branches.next]
+match = "next"
+prerelease = true
+prerelease_token = "alpha"
+
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]
 upload_to_vcs_release = true


### PR DESCRIPTION
  - Add next branch configuration for alpha pre-releases
  - Update workflows to trigger on next branch
  - Restrict PyPI deployment to main branch only